### PR TITLE
flaky tests + menu fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ STATUS_TOKEN=<TOKEN>
 
 The token only needs read access to the repository.
 
+A lot of API calls are made to gather flaky tests statistics. If you would like to
+use a different API token for it, you can add it to the .env file:
+```
+FLAKY_TESTS_TOKEN=<ANOTHER_TOKEN>
+```
+
+If not provided, the `STATUS_TOKEN` will be used.
+
+**NOTE** in dev mode, gathering flaky tests is mocked.
+
 ## Running the application in dev mode
 
 You can run your application in dev mode that enables live coding using:

--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,18 @@
             <artifactId>quarkus-openshift</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.ocpsoft.prettytime</groupId>
             <artifactId>prettytime</artifactId>
             <version>5.0.0.Final</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/src/main/java/io/quarkus/status/StatusResource.java
+++ b/src/main/java/io/quarkus/status/StatusResource.java
@@ -3,17 +3,22 @@ package io.quarkus.status;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Collection;
 import java.util.Date;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import io.quarkus.qute.TemplateExtension;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.qute.api.CheckedTemplate;
+import io.quarkus.status.flaky.FlakyService;
+import io.quarkus.status.flaky.model.TestStats;
 import io.quarkus.status.model.Stats;
 import io.quarkus.status.model.Status;
 import org.ocpsoft.prettytime.PrettyTime;
@@ -30,10 +35,20 @@ public class StatusResource {
     @Inject
     LabelsService labelsService;
 
+    @Inject
+    FlakyService flakyService;
+
     @CheckedTemplate
     public static class Templates {
         public static native TemplateInstance index(Status status);
         public static native TemplateInstance issues(Status status, Stats stats, boolean isBugs);
+        public static native TemplateInstance testFailures(String testName,
+                                                           Status status,
+                                                           TestStats testStats,
+                                                           ZonedDateTime lastUpdatedOn);
+        public static native TemplateInstance tests(Status status,
+                                                    Collection<String> tests,
+                                                    ZonedDateTime lastUpdatedOn);
     }
 
     @GET
@@ -47,6 +62,26 @@ public class StatusResource {
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance bugs() throws IOException {
         return Templates.issues(statusService.getStatus(), issuesService.getBugsMonthlyStats(), true);
+    }
+
+    @GET
+    @Path("tests")
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance tests() throws IOException {
+        return Templates.tests(statusService.getStatus(), flakyService.getTests(),
+                flakyService.getLastUpdatedOn());
+    }
+    @GET
+    @Path("testFailures")
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance testFailures(@QueryParam("testName") String testName) throws IOException {
+        // TODO: match test by substring?
+        // TODO: chart of failures in time/builds
+        // TODO: github-like array of red/green showing per PR statistics,
+        // TODO: URL to PR
+        // TODO: show the failure on click
+        return Templates.testFailures(testName, statusService.getStatus(), flakyService.getTestStats(testName),
+                flakyService.getLastUpdatedOn());
     }
 
     @GET

--- a/src/main/java/io/quarkus/status/flaky/FlakyData.java
+++ b/src/main/java/io/quarkus/status/flaky/FlakyData.java
@@ -1,0 +1,50 @@
+package io.quarkus.status.flaky;
+
+import io.quarkus.status.flaky.model.CheckRun;
+import io.quarkus.status.flaky.model.Test;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class FlakyData {
+    private final List<CheckRun> allChecks = new CopyOnWriteArrayList<>();
+    private final SortedMap<String, Test> tests = new ConcurrentSkipListMap<>();
+    private final Set<Integer> scannedChecks = new ConcurrentSkipListSet<>();
+
+    private ZonedDateTime newestFetched;
+
+    private volatile ZonedDateTime lastUpdateFinish;
+
+    public void setNewestFetched(ZonedDateTime newestFetched) {
+        this.newestFetched = newestFetched;
+    }
+
+    public void setLastUpdateFinish(ZonedDateTime lastUpdateFinish) {
+        this.lastUpdateFinish = lastUpdateFinish;
+    }
+
+    public List<CheckRun> getAllChecks() {
+        return allChecks;
+    }
+
+    public SortedMap<String, Test> getTests() {
+        return tests;
+    }
+
+    public Set<Integer> getScannedChecks() {
+        return scannedChecks;
+    }
+
+    public ZonedDateTime getNewestFetched() {
+        return newestFetched;
+    }
+
+    public ZonedDateTime getLastUpdateFinish() {
+        return lastUpdateFinish;
+    }
+}

--- a/src/main/java/io/quarkus/status/flaky/FlakyProvider.java
+++ b/src/main/java/io/quarkus/status/flaky/FlakyProvider.java
@@ -1,0 +1,8 @@
+package io.quarkus.status.flaky;
+
+import java.time.ZonedDateTime;
+
+public interface FlakyProvider {
+
+    void update(ZonedDateTime startFrom, FlakyData flakyData);
+}

--- a/src/main/java/io/quarkus/status/flaky/FlakyService.java
+++ b/src/main/java/io/quarkus/status/flaky/FlakyService.java
@@ -1,0 +1,109 @@
+package io.quarkus.status.flaky;
+
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.status.flaky.model.CheckRun;
+import io.quarkus.status.flaky.model.InvocationStatus;
+import io.quarkus.status.flaky.model.Status;
+import io.quarkus.status.flaky.model.Test;
+import io.quarkus.status.flaky.model.TestStats;
+import org.jboss.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@ApplicationScoped
+public class FlakyService {
+
+    private static final Logger log = Logger.getLogger(FlakyService.class);
+    private static final int DAYS = 10;
+    private static final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    private final FlakyData flakyData = new FlakyData();
+
+    @Inject
+    FlakyProvider flakyProvider;
+
+    @Scheduled(every = "PT1H")
+    void update() {
+        dropOld();
+        ZonedDateTime fetchStart = flakyData.getNewestFetched() == null
+                ? ZonedDateTime.now().minusDays(DAYS)
+                : flakyData.getNewestFetched().minusMinutes(5);
+        fetchNewerThan(fetchStart); // to minimize the chance of missing a run
+    }
+
+    private void dropOld() {
+        ZonedDateTime evictionCutOff = ZonedDateTime.now().minusDays(DAYS);
+
+        List<CheckRun> checksToEvict = new ArrayList<>();
+
+        for (CheckRun check : flakyData.getAllChecks()) {
+            if (check.getTime().isBefore(evictionCutOff)) {
+                checksToEvict.add(check);
+            }
+        }
+
+        flakyData.getAllChecks().removeAll(checksToEvict);
+        for (CheckRun check : checksToEvict) {
+            flakyData.getScannedChecks().remove(check.getTestRunId());
+            for (Test test : flakyData.getTests().values()) {
+                test.getErrors().remove(check);
+                test.getFailures().remove(check);
+            }
+        }
+        log.debugf("Dropped %d old checks", checksToEvict.size());
+    }
+
+    // todo info that test data is processed until it's finished
+
+    public void start(@Observes StartupEvent ignored) {
+        fetchNewerThan(ZonedDateTime.now().minusDays(30));
+    }
+
+    private void fetchNewerThan(ZonedDateTime startDate) {
+        executor.execute(() -> flakyProvider.update(startDate, flakyData));
+    }
+
+
+
+    public TestStats getTestStats(String testName) {
+        if (testName == null) {
+            return null;
+        }
+        Test test = flakyData.getTests().get(testName);
+        if (test == null) {
+            return null;
+        }
+
+        List<InvocationStatus> invocationStatuses = new ArrayList<>();
+        for (CheckRun check : flakyData.getAllChecks()) {
+            Status status;
+            if (test.getErrors().contains(check)) {
+                status = Status.ERROR;
+            } else if (test.getFailures().contains(check)) {
+                status = Status.FAILURE;
+            } else {
+                status = Status.NO_DATA;
+            }
+
+            invocationStatuses.add(new InvocationStatus(status, check));
+        }
+        return new TestStats(testName, invocationStatuses);
+    }
+
+    public ZonedDateTime getLastUpdatedOn() {
+        return flakyData.getLastUpdateFinish();
+    }
+
+    public Set<String> getTests() {
+        return flakyData.getTests().keySet();
+    }
+}

--- a/src/main/java/io/quarkus/status/flaky/GithubFlakyTestsProvider.java
+++ b/src/main/java/io/quarkus/status/flaky/GithubFlakyTestsProvider.java
@@ -1,0 +1,234 @@
+package io.quarkus.status.flaky;
+
+import io.quarkus.arc.profile.IfBuildProfile;
+import io.quarkus.status.flaky.model.CheckRun;
+import io.quarkus.status.flaky.model.Test;
+import io.quarkus.status.flaky.client.GithubClient;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient43Engine;
+import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+// TODO: artifact-> name suggests the failed job name, it may be worth showing it
+@IfBuildProfile("prod")
+@ApplicationScoped
+public class GithubFlakyTestsProvider implements FlakyProvider {
+
+    private static final Logger log = Logger.getLogger(GithubFlakyTestsProvider.class);
+
+    private static final Pattern TEST_RESULT_PATTERN = Pattern.compile(".*Tests run.*in.*$");
+    private static final Pattern TEST_NAME_PATTERN = Pattern.compile("(?<=in ).*$");
+    private static final Pattern TEST_FAILURES_PATTERN = Pattern.compile("(?<=Failures: )\\d+");
+    private static final Pattern TEST_ERRORS_PATTERN = Pattern.compile("(?<=Errors: )\\d+");
+    private static final String ORG = "quarkusio";
+    private static final String REPO = "quarkus";
+    private static final String QUARKUS_CI = "Quarkus CI";
+    private static final String REPORTS_FILE = "test-reports.tgz";
+
+    private static final int RUN_BATCH_SIZE = 50;
+    private static final String GITHUB_API_HOST = "api.github.com";
+
+    private final AtomicBoolean updateInProgress = new AtomicBoolean(false);
+
+    private final String bearerToken;
+    private final GithubClient client;
+
+    @Inject
+    GithubFlakyTestsProvider(
+            @ConfigProperty(name = "flaky.tests.token") Optional<String> token,
+            @ConfigProperty(name = "status.token") String defaultToken) {
+        this.bearerToken = "Bearer " + token.orElse(defaultToken);
+
+        ApacheHttpClient43Engine httpEngine = new ApacheHttpClient43Engine();
+        httpEngine.setFollowRedirects(true);
+        // good old resteasy client builder because it can do redirects:
+        client = new ResteasyClientBuilderImpl().httpEngine(httpEngine).build().target("https://" + GITHUB_API_HOST)
+                .proxy(GithubClient.class);
+    }
+
+    @Override
+    public void update(ZonedDateTime startDate, FlakyData flakyData) {
+        if (updateInProgress.compareAndSet(false, true)) {
+            log.info("requested flaky test data update while previous is in progress, ignoring");
+            return;
+        }
+        log.infof("Started gathering flaky tests starting from %s", startDate);
+        // go through PR runs and collect check runs and failures
+        long fetchStartTime = System.currentTimeMillis();
+        GithubClient.WorkflowList workflows = client.workflows(ORG, REPO, bearerToken);
+
+        Integer quarkusCi = null;
+        for (GithubClient.Workflow workflow : workflows.getWorkflows()) {
+            if (QUARKUS_CI.equals(workflow.getName())) {
+                quarkusCi = workflow.getId();
+                break;
+            }
+        }
+        if (quarkusCi == null) {
+            throw new IllegalStateException("Quarkus CI workflow not found. Exiting");
+        }
+
+        boolean done = false;
+        for (int pageNo = 1; !done; pageNo++) {
+            GithubClient.WorkflowRunList runs = client.runs(ORG, REPO, quarkusCi, RUN_BATCH_SIZE, pageNo, bearerToken);
+            log.debugf("fetched %d runs", runs.getWorkflow_runs().size());
+            for (GithubClient.WorkflowRun run : runs.getWorkflow_runs()) {
+
+                if (run.getCreated_at().isBefore(startDate)) {
+                    // we have at last one run that is too old, skip this one
+                    // and don't fetch the next page
+                    done = true;
+                    continue;
+                }
+
+                if (flakyData.getScannedChecks().add(run.getId())) {
+
+                    ZonedDateTime newestFetched = flakyData.getNewestFetched();
+                    if (newestFetched == null || newestFetched.isBefore(run.getCreated_at())) {
+                        flakyData.setNewestFetched(run.getCreated_at());
+                    }
+
+                    // get archived items for the run
+                    int runId = run.getId();
+                    List<GithubClient.Artifact> artifacts = fetchTestReports(runId);
+
+                    addTestResults(run, artifacts, flakyData);
+                }
+            }
+        }
+        flakyData.setLastUpdateFinish(ZonedDateTime.now());
+        log.infof("Flaky test gathering done in %s s", (System.currentTimeMillis() - fetchStartTime) / 1000);
+        updateInProgress.set(false);
+    }
+
+    private void addTestResults(GithubClient.WorkflowRun run, List<GithubClient.Artifact> artifacts, FlakyData flakyData) {
+        CheckRun checkRun = new CheckRun(run.getId(), run.getHtml_url(), run.getName(), run.getCreated_at());
+        flakyData.getAllChecks().add(checkRun);
+        for (GithubClient.Artifact artifact : artifacts) {
+            if (artifact.isExpired()) {
+                log.infof("test results archive expired for run %s", run.getHtml_url());
+            } else {
+                InputStream archive = client.artifact(ORG, REPO, artifact.getId(), bearerToken);
+                addTestResultsFromZip(archive, checkRun, flakyData);
+            }
+        }
+    }
+
+    private void addTestResultsFromZip(InputStream input, CheckRun checkRun, FlakyData flakyData) {
+        byte[] buffer = new byte[100_000];
+        ByteArrayOutputStream tgzFile;
+        try {
+            tgzFile = readTgzFromZipFile(input);
+        } catch (IOException e) {
+            log.error("Failed to decompress tgz file", e); // TODO: more info
+            return;
+        }
+
+        try (GzipCompressorInputStream gzip = new GzipCompressorInputStream(new ByteArrayInputStream(tgzFile.toByteArray()));
+             TarArchiveInputStream tarGz = new TarArchiveInputStream(gzip)) {
+            TarArchiveEntry entry;
+
+            while ((entry = (TarArchiveEntry) tarGz.getNextEntry()) != null) {
+                if (entry.getName().endsWith(".txt")) {
+                    ByteArrayOutputStream txtFileContents = new ByteArrayOutputStream();
+                    int read;
+                    while ((read = tarGz.read(buffer)) != -1) {
+                        txtFileContents.write(buffer, 0, read);
+                    }
+
+                    extractTestData(txtFileContents.toString(), checkRun, flakyData);
+                }
+            }
+        } catch (IOException e) {
+            log.error("Failed to read test results tgz file", e);
+        }
+
+    }
+
+    private void extractTestData(String text, CheckRun checkRun, FlakyData flakyData) {
+        String[] lines = text.split("\n");
+        Arrays.stream(lines).filter(line -> TEST_RESULT_PATTERN.matcher(line).matches())
+                .forEach(line -> collectTestResults(line, checkRun, flakyData));
+    }
+
+    private void collectTestResults(String line, CheckRun checkRun, FlakyData flakyData) {
+        // Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.127 s - in io.quarkus.test.common.TestResourceManagerTest
+        String testName = getSingleMatch(line, TEST_NAME_PATTERN);
+        int failures = getSingleInt(line, TEST_FAILURES_PATTERN);
+        int errors = getSingleInt(line, TEST_ERRORS_PATTERN);
+
+        Test test = flakyData.getTests().computeIfAbsent(testName, Test::new);
+        if (errors > 0) {
+            test.addError(checkRun);
+        } else if (failures > 0) {
+            test.addFailure(checkRun);
+        }
+    }
+
+    private List<GithubClient.Artifact> fetchTestReports(int runId) {
+        List<GithubClient.Artifact> result = new ArrayList<>();
+        int totalCount;
+        do {
+            GithubClient.ArtifactList artifactList = client.actionArtifacts(ORG, REPO, runId, bearerToken, 100, 0);
+            result.addAll(artifactList.getArtifacts());
+            totalCount = artifactList.getTotal_count();
+        } while (result.size() < totalCount);
+
+        return result.stream()
+                .filter(a -> a.getName().startsWith("test-reports"))
+                .collect(Collectors.toList());
+    }
+
+    private static ByteArrayOutputStream readTgzFromZipFile(InputStream inputStream) throws IOException {
+        ByteArrayOutputStream zipBytes = new ByteArrayOutputStream();
+        byte[] buffer = new byte[10_000];
+        try (ZipInputStream zip = new ZipInputStream(inputStream)) {
+            for (ZipEntry zipEntry = zip.getNextEntry(); zipEntry != null; zipEntry = zip.getNextEntry()) {
+                if (!zipEntry.isDirectory() && zipEntry.getName().endsWith(REPORTS_FILE)) {
+                    int read;
+                    while ((read = zip.read(buffer)) > 0) {
+                        zipBytes.write(buffer, 0, read);
+                    }
+                }
+                zip.closeEntry();
+            }
+            return zipBytes;
+        }
+    }
+
+    private static int getSingleInt(String logLine, Pattern pattern) {
+        String runAsString = getSingleMatch(logLine, pattern);
+        return Integer.parseInt(runAsString);
+    }
+
+    private static String getSingleMatch(String logLine, Pattern pattern) {
+        Matcher matcher = pattern.matcher(logLine);
+        if (matcher.find()) {
+            return matcher.group();
+        } else {
+            throw new IllegalArgumentException("failed to determine test name from " + logLine);
+        }
+    }
+
+}

--- a/src/main/java/io/quarkus/status/flaky/MockFlakyTestsProvider.java
+++ b/src/main/java/io/quarkus/status/flaky/MockFlakyTestsProvider.java
@@ -1,0 +1,56 @@
+package io.quarkus.status.flaky;
+
+import io.quarkus.arc.profile.UnlessBuildProfile;
+import io.quarkus.status.flaky.model.CheckRun;
+import io.quarkus.status.flaky.model.Test;
+import org.jboss.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.time.ZonedDateTime;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+
+@UnlessBuildProfile("prod")
+@ApplicationScoped
+public class MockFlakyTestsProvider implements FlakyProvider {
+
+    private static final Logger log = Logger.getLogger(MockFlakyTestsProvider.class);
+
+    private static final String TEST_A = "com.example.TestA";
+    private static final String TEST_B = "com.example.TestB";
+    private static final String TEST_C = "com.example.TestC";
+
+    // we only do mock update once
+    private AtomicBoolean initialRun = new AtomicBoolean(true);
+
+    @Override
+    public void update(ZonedDateTime startFrom, FlakyData flakyData) {
+        // three check runs, on first only com.example.TestA fails, on second
+        // com.example.TestB and com.example.TestC, on third no test fail
+
+        ZonedDateTime failureTime = ZonedDateTime.now().minusHours(10);
+        if (initialRun.compareAndSet(true, false)) {
+
+            CheckRun checkRun1 = new CheckRun(1, "http://example.com/check1", "Quarkus CI", failureTime);
+            CheckRun checkRun2 = new CheckRun(2, "http://example.com/check1", "Quarkus CI", failureTime);
+            CheckRun checkRun3 = new CheckRun(3, "http://example.com/check1", "Quarkus CI", failureTime);
+
+            flakyData.getTests()
+                    .put(TEST_A, new Test(TEST_A).addError(checkRun1)
+                            .addFailure(checkRun2));
+            flakyData.getTests()
+                    .put(TEST_B, new Test(TEST_B).addFailure(checkRun2));
+            flakyData.getTests()
+                    .put(TEST_C, new Test(TEST_C).addError(checkRun2));
+
+            Stream.of(checkRun1, checkRun2, checkRun3)
+                    .forEach(ch -> {
+                        flakyData.getScannedChecks().add(ch.getTestRunId());
+                        flakyData.getAllChecks().add(ch);
+                    });
+            flakyData.setNewestFetched(failureTime);
+            flakyData.setLastUpdateFinish(ZonedDateTime.now());
+            log.info("Mock test data initialized");
+        }
+    }
+}

--- a/src/main/java/io/quarkus/status/flaky/client/GithubClient.java
+++ b/src/main/java/io/quarkus/status/flaky/client/GithubClient.java
@@ -1,0 +1,220 @@
+package io.quarkus.status.flaky.client;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import java.io.InputStream;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Path("/repos/{owner}/{repo}")
+@Produces("application/vnd.github.v3+json")
+@Retry(delay = 1, delayUnit = ChronoUnit.MINUTES)
+public interface GithubClient {
+    @GET
+    @Path("/actions/runs/{runId}/artifacts")
+    ArtifactList actionArtifacts(@PathParam("owner") String owner,
+                                 @PathParam("repo") String repo,
+                                 @PathParam("runId") long runId,
+                                 @HeaderParam("Authorization") String bearerToken,
+                                 @QueryParam("per_page") int per_page,
+                                 @QueryParam("page") int page);
+
+    @GET
+    @Path("/actions/workflows")
+    WorkflowList workflows(@PathParam("owner") String owner,
+                           @PathParam("repo") String repo,
+                           @HeaderParam("Authorization") String bearerToken);
+
+    @GET
+    @Path("/actions/workflows/{workflowId}/runs")
+    WorkflowRunList runs(@PathParam("owner") String owner,
+                         @PathParam("repo") String repo,
+                         @PathParam("workflowId") int workflowId,
+                         @QueryParam("per_page") int pageSize,
+                         @QueryParam("page") int pageNumber,
+                         @HeaderParam("Authorization") String bearerToken);
+
+    @GET
+    @Path("/actions/artifacts/{artifactId}/zip")
+    InputStream artifact(@PathParam("owner") String owner,
+                         @PathParam("repo") String repo,
+                         @PathParam("artifactId") int id,
+                         @HeaderParam("Authorization") String bearerToken);
+
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    class Workflow {
+        String name;
+        int id;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    class WorkflowList {
+        int total_count;
+        List<Workflow> workflows;
+
+        public int getTotal_count() {
+            return total_count;
+        }
+
+        public void setTotal_count(int total_count) {
+            this.total_count = total_count;
+        }
+
+        public List<Workflow> getWorkflows() {
+            return workflows;
+        }
+
+        public void setWorkflows(List<Workflow> workflows) {
+            this.workflows = workflows;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    class WorkflowRun {
+        private int id;
+        private String html_url;
+        private String name;
+        private ZonedDateTime created_at;
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public String getHtml_url() {
+            return html_url;
+        }
+
+        public void setHtml_url(String html_url) {
+            this.html_url = html_url;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public ZonedDateTime getCreated_at() {
+            return created_at;
+        }
+
+        public void setCreated_at(ZonedDateTime created_at) {
+            this.created_at = created_at;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    class WorkflowRunList {
+        int total_count;
+        List<WorkflowRun> workflow_runs;
+
+        public int getTotal_count() {
+            return total_count;
+        }
+
+        public void setTotal_count(int total_count) {
+            this.total_count = total_count;
+        }
+
+        public List<WorkflowRun> getWorkflow_runs() {
+            return workflow_runs;
+        }
+
+        public void setWorkflow_runs(List<WorkflowRun> workflow_runs) {
+            this.workflow_runs = workflow_runs;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    class ArtifactList {
+        int total_count;
+        List<Artifact> artifacts;
+
+        public int getTotal_count() {
+            return total_count;
+        }
+
+        public void setTotal_count(int total_count) {
+            this.total_count = total_count;
+        }
+
+        public List<Artifact> getArtifacts() {
+            return artifacts;
+        }
+
+        public void setArtifacts(List<Artifact> artifacts) {
+            this.artifacts = artifacts;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    class Artifact {
+        int id;
+        String archive_download_url;
+        boolean expired;
+        String name; // test-report
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public String getArchive_download_url() {
+            return archive_download_url;
+        }
+
+        public void setArchive_download_url(String archive_download_url) {
+            this.archive_download_url = archive_download_url;
+        }
+
+        public boolean isExpired() {
+            return expired;
+        }
+
+        public void setExpired(boolean expired) {
+            this.expired = expired;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/src/main/java/io/quarkus/status/flaky/model/CheckRun.java
+++ b/src/main/java/io/quarkus/status/flaky/model/CheckRun.java
@@ -1,0 +1,51 @@
+package io.quarkus.status.flaky.model;
+
+import java.time.ZonedDateTime;
+import java.util.Objects;
+
+public class CheckRun {
+    private int testRunId;
+    private String githubActionsUrl;
+    private String jobName;
+    private ZonedDateTime time;
+
+    public CheckRun(int testRunId, String githubActionsUrl, String jobName, ZonedDateTime time) {
+        this.testRunId = testRunId;
+        this.githubActionsUrl = githubActionsUrl;
+        this.jobName = jobName;
+        this.time = time;
+    }
+
+    public int getTestRunId() {
+        return testRunId;
+    }
+
+    public String getGithubActionsUrl() {
+        return githubActionsUrl;
+    }
+
+    public String getJobName() {
+        return jobName;
+    }
+
+    public void setJobName(String jobName) {
+        this.jobName = jobName;
+    }
+
+    public ZonedDateTime getTime() {
+        return time;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CheckRun checkRun = (CheckRun) o;
+        return Objects.equals(testRunId, checkRun.testRunId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(testRunId);
+    }
+}

--- a/src/main/java/io/quarkus/status/flaky/model/InvocationStatus.java
+++ b/src/main/java/io/quarkus/status/flaky/model/InvocationStatus.java
@@ -1,0 +1,19 @@
+package io.quarkus.status.flaky.model;
+
+public class InvocationStatus {
+    private final Status status;
+    private final CheckRun checkRun;
+
+    public InvocationStatus(Status status, CheckRun checkRun) {
+        this.status = status;
+        this.checkRun = checkRun;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public CheckRun getCheckRun() {
+        return checkRun;
+    }
+}

--- a/src/main/java/io/quarkus/status/flaky/model/Status.java
+++ b/src/main/java/io/quarkus/status/flaky/model/Status.java
@@ -1,0 +1,7 @@
+package io.quarkus.status.flaky.model;
+
+public enum Status {
+    NO_DATA, // in future, split to SKIPPED and SUCCESS
+    ERROR, // at least one test method failed with error
+    FAILURE // at least one test method failed with failure
+}

--- a/src/main/java/io/quarkus/status/flaky/model/Test.java
+++ b/src/main/java/io/quarkus/status/flaky/model/Test.java
@@ -1,0 +1,37 @@
+package io.quarkus.status.flaky.model;
+
+import io.vertx.core.impl.ConcurrentHashSet;
+
+import java.util.Set;
+
+public class Test {
+    private String testName;
+    private final Set<CheckRun> failures = new ConcurrentHashSet<>(); // this will hopefully be very small
+    private final Set<CheckRun> errors = new ConcurrentHashSet<>(); // this will hopefully be very small
+
+    public Test(String testName) {
+        this.testName = testName;
+    }
+
+    public Test addFailure(CheckRun checkRun) {
+        failures.add(checkRun);
+        return this;
+    }
+
+    public Test addError(CheckRun checkRun) {
+        errors.add(checkRun);
+        return this;
+    }
+
+    public String getTestName() {
+        return testName;
+    }
+
+    public Set<CheckRun> getFailures() {
+        return failures;
+    }
+
+    public Set<CheckRun> getErrors() {
+        return errors;
+    }
+}

--- a/src/main/java/io/quarkus/status/flaky/model/TestStats.java
+++ b/src/main/java/io/quarkus/status/flaky/model/TestStats.java
@@ -1,0 +1,22 @@
+package io.quarkus.status.flaky.model;
+
+import java.util.List;
+
+public class TestStats {
+    private final String testName;
+    private final List<InvocationStatus> invocations;
+
+    public TestStats(String testName,
+                      List<InvocationStatus> invocations) {
+        this.testName = testName;
+        this.invocations = invocations;
+    }
+
+    public String getTestName() {
+        return testName;
+    }
+
+    public List<InvocationStatus> getInvocations() {
+        return invocations;
+    }
+}

--- a/src/main/resources/META-INF/resources/css/main.css
+++ b/src/main/resources/META-INF/resources/css/main.css
@@ -34,3 +34,14 @@
 .ui.icon.message > i.icon:not(.close) {
 	font-size: 1em;
 }
+
+.flaky-input {
+    margin: 2em
+}
+
+.flaky-results {
+    margin: 2em;
+    padding: 2em;
+    background-color: #fafafa;
+    box-shadow: 2px 2px 2px #909090
+}

--- a/src/main/resources/templates/StatusResource/base.html
+++ b/src/main/resources/templates/StatusResource/base.html
@@ -16,7 +16,7 @@
 			Status
 		</a>
 		{#for section in status.sections}
-		<a class="header item" href="#{section.key}">
+		<a class="header item" href="/#{section.key}">
 			<small>{section.value.name}</small>&nbsp;&nbsp;
 			{#if section.value.failure}
 				<i class="red icon exclamation circle"></i>
@@ -27,6 +27,9 @@
 		{/for}
 		<a class="header item" href="/bugs/">
 			Issues Deep Dive
+		</a>
+		<a class="header item" href="/tests/">
+			PR Test Failures
 		</a>
 	</div>
 	<div class="main-content">

--- a/src/main/resources/templates/StatusResource/testFailures.html
+++ b/src/main/resources/templates/StatusResource/testFailures.html
@@ -1,0 +1,52 @@
+{#include StatusResource/base}
+
+{#body}
+<div class="ui main container">
+
+    <a href="/tests">&lt; List of tests</a>
+
+    <div class="flaky-input">
+        <label for="testName">Fully qualified test class name:</label><input type="text" id="testName">
+        <button type="button" onclick="showTestStats()">Show test failures</button>
+    </div>
+
+    <div class="flaky-results">
+            {#if testStats != null}
+            <h4>Test failures and errors for {testName}</h4>
+            <ul>
+                {#for invocation in testStats.invocations}
+                    {#when invocation.status}
+                        {#is in ERROR FAILURE}
+                            <li>{invocation.status} in
+                                <a href="{invocation.checkRun.githubActionsUrl}">check id: {invocation.checkRun.testRunId}
+                                    at {invocation.checkRun.time.format('yyyy/MM/dd HH:mm')}</a>
+                            </li>
+                    {/when}
+                {/for}
+            </ul>
+            {#else}
+            {#if testName != null}
+                <h4>No test failures for {testName} found. Make sure you are using fully qualified class name</h4>
+                {/if}
+             {/if}
+    </div>
+</div>
+{/body}
+
+{#scripts}
+<script>
+    var testNameInput = document.getElementById("testName");
+    testNameInput.onkeydown = e => \{if (e.key=="Enter")  showTestStats()\}
+
+    function showTestStats() {
+        console.log("in showTestStats");
+        var testName = document.getElementById("testName").value;
+        console.log("element: ", document.getElementById("testName"));
+        console.log("value: ", testName);
+        window.location.href = '/testFailures?testName=' + testName;
+    }
+
+</script>
+{/scripts}
+
+{/include}

--- a/src/main/resources/templates/StatusResource/tests.html
+++ b/src/main/resources/templates/StatusResource/tests.html
@@ -1,0 +1,38 @@
+{#include StatusResource/base}
+
+{#body}
+<div class="ui main container">
+
+    <div class="flaky-input">
+        <label for="testName">Find test by fully qualified test class name:</label><input type="text" id="testName">
+        <button type="button" onclick="showTestStats()">Show test failures</button>
+    </div>
+
+    <div class="flaky-results">
+        <h4>Known tests</h4>
+        <ul>
+            {#for test in tests}
+                <li><a href="/testFailures?testName={test}">{test}</a></li>
+            {/for}
+        </ul>
+    </div>
+</div>
+{/body}
+
+{#scripts}
+<script>
+    var testNameInput = document.getElementById("testName");
+    testNameInput.onkeydown = e => \{if (e.key=="Enter")  showTestStats()\}
+
+    function showTestStats() {
+        console.log("in showTestStats");
+        var testName = document.getElementById("testName").value;
+        console.log("element: ", document.getElementById("testName"));
+        console.log("value: ", testName);
+        window.location.href = '/testFailures?test=' + testName;
+    }
+
+</script>
+{/scripts}
+
+{/include}


### PR DESCRIPTION
This PR adds `PR Test Failures` to the app.

![image](https://user-images.githubusercontent.com/3901322/110092998-884b3d80-7d9a-11eb-8e4d-d0aca6a3add9.png)

When a test is clicked, or it's fully qualified name is entered, it shows a list of failures and errors for the build:
![image](https://user-images.githubusercontent.com/3901322/110093180-b03aa100-7d9a-11eb-9d36-9e10481cb83b.png)

Link on the list redirects to the github actions page for the check that failed.

We have no database now so the test information is kept in memory. On application start, test failures from last 30 days are gathered. Later, hourly, the information is updated (only new checks are processed).

Initial gathering of information takes ca. 15 minutes on my laptop, uses a single thread, and is mainly IO, so it shouldn't impact app's performance a lot.