### PR TITLE
add info about test failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ STATUS_TOKEN=<TOKEN>
 
 The token only needs read access to the repository.
 
+A lot of API calls are made to gather flaky tests statistics. If you would like to
+use a different API token for it, you can add it to the .env file:
+```
+FLAKY_TESTS_TOKEN=<ANOTHER_TOKEN>
+```
+
+If not provided, the `STATUS_TOKEN` will be used.
+
+**NOTE** in dev mode, gathering flaky tests is mocked.
+
 ## Running the application in dev mode
 
 You can run your application in dev mode that enables live coding using:

--- a/ddl.sql
+++ b/ddl.sql
@@ -1,0 +1,43 @@
+CREATE SEQUENCE hibernate_sequence
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER TABLE hibernate_sequence OWNER TO quarkus;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+CREATE TABLE testexecution (
+                                      id bigint NOT NULL,
+                                      successful boolean NOT NULL,
+                                      testname character varying(255),
+                                      job_id bigint
+);
+
+ALTER TABLE testexecution OWNER TO quarkus;
+
+CREATE TABLE testjob (
+                                id bigint NOT NULL,
+                                completedat timestamp without time zone,
+                                name character varying(255),
+                                sha character varying(255),
+                                url character varying(255)
+);
+
+ALTER TABLE testjob OWNER TO quarkus;
+
+ALTER TABLE ONLY testexecution
+    ADD CONSTRAINT testexecution_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY testjob
+    ADD CONSTRAINT testjob_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY testexecution
+    ADD CONSTRAINT fkptkmwmynles1g3xwdo7iudrun FOREIGN KEY (job_id) REFERENCES testjob(id);
+
+create index on testexecution (testname, id desc, successful);
+create index on testexecution using btree (testname);

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,22 @@
             <artifactId>quarkus-prettytime</artifactId>
             <version>0.1.1</version>
         </dependency>
+
+        <!-- database: -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-panache</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>

--- a/src/main/java/io/quarkus/status/flaky/TestDataInitializer.java
+++ b/src/main/java/io/quarkus/status/flaky/TestDataInitializer.java
@@ -1,0 +1,105 @@
+package io.quarkus.status.flaky;
+
+import io.quarkus.arc.profile.UnlessBuildProfile;
+import io.quarkus.runtime.StartupEvent;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+
+import java.util.Date;
+import java.util.Random;
+
+import static io.quarkus.status.flaky.TestStatisticsResource.RESULT_GROUP_SIZE;
+
+@ApplicationScoped
+@UnlessBuildProfile("prod")
+public class TestDataInitializer {
+    @Transactional
+    public void setUp(@Observes StartupEvent anything) {
+        TestJob testJob = new TestJob();
+        testJob.name = "JVM tests on Windows";
+        testJob.url = "https://example.com/test-result";
+        testJob.completedAt = new Date();
+        testJob.sha = "093245802938402934902341";
+        TestJob.persist(testJob);
+
+        for (int i = 0; i < 10; i++) {
+            TestExecution execution = new TestExecution();
+            execution.job = testJob;
+            execution.testName = "com.example.restclient.it.SomeTest.alwaysFailingTest";
+            execution.successful = false;
+            TestExecution.persist(execution);
+        }
+        for (int i = 0; i < 10; i++) {
+            TestExecution execution = new TestExecution();
+            execution.job = testJob;
+            execution.testName = "always.succeeding.test";
+            execution.successful = true;
+            TestExecution.persist(execution);
+        }
+
+
+        for (int i = 0; i < RESULT_GROUP_SIZE; i++) {
+            TestExecution execution = new TestExecution();
+            execution.job = testJob;
+            execution.testName = "half.failing.test";
+            execution.successful = (i % 2) == 0;
+            TestExecution.persist(execution);
+        }
+        for (int i = 0; i < RESULT_GROUP_SIZE * 2; i++) {
+            TestExecution execution = new TestExecution();
+            execution.job = testJob;
+            execution.testName = "test.failing.in.the.past";
+            execution.successful = i >= RESULT_GROUP_SIZE;
+            TestExecution.persist(execution);
+        }
+        for (int i = 0; i < RESULT_GROUP_SIZE * 2; i++) {
+            TestExecution execution = new TestExecution();
+            execution.job = testJob;
+            execution.testName = "test.successful.in.the.past";
+            execution.successful = i <= RESULT_GROUP_SIZE;
+            TestExecution.persist(execution);
+        }
+    }
+
+    @Inject
+    PerfTestInitializer perfTestInitializer;
+
+    public void createDataForPerfTest(@Observes StartupEvent anything) {
+        if (!Boolean.TRUE.toString().equalsIgnoreCase(System.getenv("generate_perf_test_data"))) {
+            return;
+        }
+        Random r = new Random();
+        for (int i = 0; i < 600; i++) {
+            String testName = "test.successful.in.the.past" + r.nextInt();
+            perfTestInitializer.initTestResults(testName);
+        }
+        System.out.println("\ndone");
+    }
+
+    @ApplicationScoped
+    public static class PerfTestInitializer {
+
+        public static final int TEST_ROWS_FOR_TEST = 50;
+
+        @Transactional
+        void initTestResults(String testName) {
+            TestJob testJob = new TestJob();
+            testJob.name = "JVM tests on Linux";
+            testJob.url = "https://example.com/test-result/2";
+            testJob.completedAt = new Date();
+            testJob.sha = "123132423412313242341";
+            TestJob.persist(testJob);
+            Random r = new Random();
+            for (int i = 0; i < TEST_ROWS_FOR_TEST; i++) {
+                TestExecution execution = new TestExecution();
+                execution.job = testJob;
+                execution.testName = testName;
+                execution.successful = r.nextDouble() > 0.1;
+                TestExecution.persist(execution);
+            }
+        }
+    }
+}

--- a/src/main/java/io/quarkus/status/flaky/TestExecution.java
+++ b/src/main/java/io/quarkus/status/flaky/TestExecution.java
@@ -1,0 +1,29 @@
+package io.quarkus.status.flaky;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+import javax.persistence.Entity;
+import javax.persistence.Index;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(indexes = {
+        @Index(columnList = "testName"),
+        @Index(columnList = "testName, id desc, successful")
+})
+public class TestExecution extends PanacheEntity {
+    public String testName;
+    public boolean successful;
+    @ManyToOne
+    public TestJob job;
+
+    @Override
+    public String toString() {
+        return "TestExecution{" +
+                "testName='" + testName + '\'' +
+                ", successful=" + successful +
+                ", id=" + id +
+                '}';
+    }
+}

--- a/src/main/java/io/quarkus/status/flaky/TestJob.java
+++ b/src/main/java/io/quarkus/status/flaky/TestJob.java
@@ -1,0 +1,14 @@
+package io.quarkus.status.flaky;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+import javax.persistence.Entity;
+import java.util.Date;
+
+@Entity
+public class TestJob extends PanacheEntity {
+    public String url;
+    public String name;
+    public Date completedAt;
+    public String sha;
+}

--- a/src/main/java/io/quarkus/status/flaky/TestReportFeedingTube.java
+++ b/src/main/java/io/quarkus/status/flaky/TestReportFeedingTube.java
@@ -1,0 +1,48 @@
+package io.quarkus.status.flaky;
+
+import io.quarkus.status.flaky.TestExecution;
+import io.quarkus.status.flaky.TestJob;
+import io.quarkus.status.flaky.feeding.JobResult;
+import io.quarkus.status.flaky.feeding.TestResultDto;
+import io.quarkus.status.flaky.feeding.WorkflowResult;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@Path("/test-results")
+@RolesAllowed("quarkus-bot")
+public class TestReportFeedingTube {
+
+    @Inject
+    TestStatisticsResource statisticsResource;
+
+    @POST
+    @Transactional
+    public Response storeTestResults(WorkflowResult results) {
+        for (JobResult job : results.getJobs()) {
+            var testJob = new TestJob();
+            testJob.url = job.getJobUrl();
+            testJob.name = job.getJobName();
+            testJob.completedAt = job.getCompletedAt();
+            testJob.sha = results.getSha();
+            TestJob.persist(testJob);
+
+            for (TestResultDto test : job.getTests()) {
+                var testExecution = new TestExecution();
+                testExecution.testName = test.getName();
+                testExecution.successful = test.isSuccessful();
+                testExecution.job = testJob;
+
+                TestExecution.persist(testExecution);
+            }
+        }
+
+        statisticsResource.clearCache();
+
+        return Response.ok().build();
+    }
+}

--- a/src/main/java/io/quarkus/status/flaky/TestStatisticsResource.java
+++ b/src/main/java/io/quarkus/status/flaky/TestStatisticsResource.java
@@ -1,0 +1,98 @@
+package io.quarkus.status.flaky;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Path("/test-statistics")
+@ApplicationScoped
+public class TestStatisticsResource {
+    private static final int TESTS_TABLE_SIZE = 20;
+    static final int RESULT_GROUP_SIZE = 40;
+
+    @ConfigProperty(name = "status.flaky.max-cache-size", defaultValue = "10000")
+    Integer maxCacheSize;
+
+    @PersistenceContext
+    EntityManager entityManager;
+
+    private Cache<String, List<TestStatistics>> queryCache; // effectively final
+
+    @PostConstruct
+    void init() {
+        queryCache = Caffeine.newBuilder().maximumSize(maxCacheSize).build();
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<TestStatistics> getStats(@QueryParam("testQuery") String testQueryParam) {
+        String testQuery = testQueryParam == null || testQueryParam.isBlank()
+                ? "%"
+                : '%' + testQueryParam + '%';
+        List<TestStatistics> cachedResult = queryCache.getIfPresent(testQuery);
+        if (cachedResult != null) {
+            return cachedResult;
+        }
+
+        if (!testQuery.equals("%")) {
+            Query countQuery = entityManager.createNativeQuery(
+                    "select count(t.*) from (select distinct testname from testexecution where testname like :test) t");
+            countQuery.setParameter("test", testQuery);
+            BigInteger count = (BigInteger) countQuery.getSingleResult();
+
+            if (count.intValue() > 100) {
+                throw new BadRequestException(Response.status(400)
+                        .entity("Too many tests matching the query found, please use a more specific query").build());
+            }
+        }
+
+        Query query = entityManager.createNativeQuery("with partitioned_results as " +
+                "(select id, testname, successful\\:\\:int as success, row_number() over (partition by testname order by id desc) from testexecution)" +
+                "select testname, avg(success) as success_rate, sum(success), count(id) from partitioned_results " +
+                "where testname like :test and row_number <= " + RESULT_GROUP_SIZE + " group by testname order by success_rate asc limit " + TESTS_TABLE_SIZE);
+
+        query.setParameter("test", testQuery);
+        List<Object[]> stats = query.getResultList();
+        List<TestStatistics> result = stats.stream()
+                .map(TestStatistics::new)
+                .collect(Collectors.toList());
+
+        queryCache.put(testQuery, result);
+        return result;
+    }
+
+    void clearCache() {
+        queryCache.invalidateAll();
+    }
+
+    public static class TestStatistics {
+        public String name;
+        public double failureRatio;
+        public int successCount;
+        public int executionCount;
+
+        public TestStatistics(Object[] result) {
+            this.name = (String) result[0];
+            this.failureRatio = 1 - ((BigDecimal) result[1]).doubleValue();
+            this.successCount = ((BigInteger) result[2]).intValue();
+            this.executionCount = ((BigInteger) result[3]).intValue();
+        }
+    }
+}

--- a/src/main/java/io/quarkus/status/flaky/feeding/JobResult.java
+++ b/src/main/java/io/quarkus/status/flaky/feeding/JobResult.java
@@ -1,0 +1,44 @@
+package io.quarkus.status.flaky.feeding;
+
+import java.util.Date;
+import java.util.List;
+
+public class JobResult {
+    private String jobUrl;
+    private String jobName;
+    private Date completedAt;
+
+    private List<TestResultDto> tests;
+
+    public String getJobUrl() {
+        return jobUrl;
+    }
+
+    public String getJobName() {
+        return jobName;
+    }
+
+    public List<TestResultDto> getTests() {
+        return tests;
+    }
+
+    public Date getCompletedAt() {
+        return completedAt;
+    }
+
+    public void setJobUrl(String jobUrl) {
+        this.jobUrl = jobUrl;
+    }
+
+    public void setJobName(String jobName) {
+        this.jobName = jobName;
+    }
+
+    public void setCompletedAt(Date completedAt) {
+        this.completedAt = completedAt;
+    }
+
+    public void setTests(List<TestResultDto> tests) {
+        this.tests = tests;
+    }
+}

--- a/src/main/java/io/quarkus/status/flaky/feeding/TestResultDto.java
+++ b/src/main/java/io/quarkus/status/flaky/feeding/TestResultDto.java
@@ -1,0 +1,19 @@
+package io.quarkus.status.flaky.feeding;
+
+public class TestResultDto {
+    private String name;
+    private boolean successful;
+
+    public TestResultDto(String name, boolean successful) {
+        this.name = name;
+        this.successful = successful;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isSuccessful() {
+        return successful;
+    }
+}

--- a/src/main/java/io/quarkus/status/flaky/feeding/WorkflowResult.java
+++ b/src/main/java/io/quarkus/status/flaky/feeding/WorkflowResult.java
@@ -1,0 +1,27 @@
+package io.quarkus.status.flaky.feeding;
+
+import java.util.List;
+
+public class WorkflowResult {
+    private List<JobResult> jobs;
+    private String sha;
+
+    public WorkflowResult() {
+    }
+
+    public WorkflowResult(List<JobResult> jobs) {
+        this.jobs = jobs;
+    }
+
+    public List<JobResult> getJobs() {
+        return jobs;
+    }
+
+    public String getSha() {
+        return sha;
+    }
+
+    public void setSha(String sha) {
+        this.sha = sha;
+    }
+}

--- a/src/main/resources/META-INF/resources/css/main.css
+++ b/src/main/resources/META-INF/resources/css/main.css
@@ -34,3 +34,18 @@
 .ui.icon.message > i.icon:not(.close) {
 	font-size: 1em;
 }
+
+.flaky-results {
+    margin: 2em;
+    padding: 2em;
+    background-color: #fafafa;
+    box-shadow: 2px 2px 2px #909090
+}
+
+.success-row {
+	background-color: #f0fff0;
+}
+.failure-row {
+	background-color: #ffe0e0;
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,5 +9,16 @@ quarkus.openshift.route.host=status.quarkus.io
 quarkus.openshift.annotations."kubernetes.io/tls-acme"=true
 quarkus.openshift.env.secrets=quarkus-status-token
 
+quarkus.security.users.embedded.enabled=true
+quarkus.security.users.embedded.plain-text=true
+%dev.quarkus.security.users.embedded.users.quarkusbot=123
+%test.quarkus.security.users.embedded.users.quarkusbot=123
+quarkus.security.users.embedded.roles.quarkusbot=quarkus-bot
+
 %dev.status.issues.stats.start=2020-09-01
 %dev.status.labels.subset=true
+
+%dev.quarkus.http.port=8282
+
+# drop and create the database at startup (use `update` to only update the schema)
+%dev.quarkus.hibernate-orm.database.generation=drop-and-create

--- a/src/main/resources/templates/StatusResource/base.html
+++ b/src/main/resources/templates/StatusResource/base.html
@@ -28,6 +28,9 @@
 		<a class="header item" href="/bugs/">
 			Issues Deep Dive
 		</a>
+		<a class="header item" href="/tests/">
+			PR Test Failures
+		</a>
 	</div>
 	<div class="main-content">
 		{#insert body /}

--- a/src/main/resources/templates/StatusResource/testResults.html
+++ b/src/main/resources/templates/StatusResource/testResults.html
@@ -1,0 +1,38 @@
+{#include StatusResource/base}
+
+{#body}
+<div class="ui main container">
+
+    <a href="/tests">&lt; List of tests</a>
+
+    <table class="ui table">
+        <thead>
+        <tr>
+            <th>Job name</th>
+            <th>Job name</th>
+            <th>Job URL</th>
+            <th>Date completed</th>
+            <th>Status</th>
+        </tr>
+        </thead>
+        <tbody>
+
+        {#for testExecution in executions}
+        <tr class="{testExecution.successful ? 'success-row' : 'failure-row'}">
+            <td>{testExecution.successful ? 'SUCCESS' : 'FAILURE'}</td>
+            <td>{testExecution.job.name}</td>
+            <td>{testExecution.job.completedAt}</td>
+            <td>{testExecution.job.completedAt}</td>
+            <td><a href="{testExecution.job.url}{testExecution.id}?{testExecution.successful}">Go to Job on Github Actions</a></td>
+        </tr>
+        {/for}
+        </tbody>
+    </table>
+
+</div>
+{/body}
+
+{#scripts}
+{/scripts}
+
+{/include}

--- a/src/main/resources/templates/StatusResource/tests.html
+++ b/src/main/resources/templates/StatusResource/tests.html
@@ -1,0 +1,107 @@
+{#include StatusResource/base}
+
+{#body}
+<div class="ui main container">
+
+    <div class="ui fluid form">
+        <div class="field">
+            <div class="ui label">Filter tests by name:</div>
+            <input type="text" class="ui input" id="testQuery" placeholder="test name substring">
+        </div>
+        <button type="button" class="ui button secondary" onclick="showTestStats()">Show tests</button>
+        <div id="error-div" class="ui negative message" style="visibility: hidden">
+            <i class="close icon"></i>
+            <div id="error-message" class="header">
+
+            </div>
+        </div>
+    </div>
+
+    <table class="ui striped table">
+        <thead>
+        <tr>
+            <th>Test name</th>
+            <th>Failure count</th>
+            <th>Failure ratio (in at most 40 last runs)</th>
+            <th></th>
+        </tr>
+        </thead>
+        <tbody id="test-results">
+
+        </tbody>
+    </table>
+</div>
+{/body}
+
+{#scripts}
+<script>
+    const TEST_QUERY = 'testQuery';
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const testQuery = urlParams.get(TEST_QUERY);
+
+    const testList = document.getElementById("test-results");
+    const testNameInput = document.getElementById("testQuery");
+    testNameInput.onkeydown = e => \{
+        if (e.key == "Enter") {
+            showTestStats()
+        }
+    }
+
+    if (testQuery) {
+        testNameInput.value = testQuery;
+    }
+
+    showTestStats();
+
+    function fillTestTable(data) {
+        if (!data) {
+            return;
+        }
+        testList.innerHTML = '';
+
+        data.reverse().forEach(row => {
+            const newRow = testList.insertRow(0);
+            newRow.insertCell(0).innerText = row.name;
+            newRow.insertCell(1).innerText = '' + (row.executionCount - row.successCount) + ' out of ' + row.executionCount;
+            newRow.insertCell(2).innerText = Math.floor(row.failureRatio * 100) + " %";
+            newRow.insertCell(3).innerHTML = `<a href="/test-details/$\{row.name}" class="ui button">Details</a>`
+        })
+    }
+
+    function showTestStats() {
+        document.getElementById("error-div").style.visibility = "hidden";
+        console.log("in showTestStats");
+        let testName = testNameInput.value;
+        console.log("element: ", testNameInput);
+        console.log("value: ", testName);
+
+        if (!testName) {
+            testName = '';
+        }
+        const url = new URL(location.href);
+        url.searchParams.set(TEST_QUERY, testName);
+        history.pushState(null, '', url.toString());
+
+        fetch(`/test-statistics?testQuery=$\{testNameInput.value}`)
+            .then(response => {
+                console.log(response);
+                if (response.status > 300) {
+                    response.text().then(
+                        result => {
+                            document.getElementById("error-message").innerText = result;
+                            document.getElementById("error-div").style.visibility = "visible";
+                            console.log("result '" + result + "'");
+                        }
+                    )
+                } else {
+                    return response.text()
+                        .then(result => fillTestTable(JSON.parse(result)));
+                }
+            });
+    }
+
+</script>
+{/scripts}
+
+{/include}


### PR DESCRIPTION
This change requires adding a postgresql database for the quarkus-status application and configuring security for the resource for feeding flaky tests data.

Corresponding PR for the quarkus-bot: https://github.com/quarkusio/quarkus-github-bot/pull/148

![flaky-tests](https://user-images.githubusercontent.com/3901322/134352437-e5978d1b-31c3-482d-a690-01fc37cac8fb.png)
![flaky-tets-search-by-substring](https://user-images.githubusercontent.com/3901322/134352446-df2e2192-f080-47a2-a7ec-007037152e15.png)
![flaky-tests-details](https://user-images.githubusercontent.com/3901322/134352460-37aa106d-9b16-430e-bdae-eaa3d9b7e1b0.png)
![flaky-tets-search-by-substring](https://user-images.githubusercontent.com/3901322/134352622-2e8d3b53-110d-4bd9-8778-5e3c057c96c4.png)


