### PR TITLE
Fix GitHub links in charts by using full format for the time window string

### DIFF
--- a/src/main/java/io/quarkus/status/github/GitHubService.java
+++ b/src/main/java/io/quarkus/status/github/GitHubService.java
@@ -103,6 +103,7 @@ public class GitHubService {
 
         StatsEntry statsEntry = new StatsEntry();
         statsEntry.entryName = entryName;
+        statsEntry.timeWindow = timeWindow;
         statsEntry.created = data.getJsonObject("created").getInt("issueCount");
         statsEntry.createdAndClosedNow = data.getJsonObject("createdAndClosedNow").getInt("issueCount");
         statsEntry.createdAndOpenNow = data.getJsonObject("createdAndStillOpen").getInt("issueCount");

--- a/src/main/java/io/quarkus/status/model/StatsEntry.java
+++ b/src/main/java/io/quarkus/status/model/StatsEntry.java
@@ -5,6 +5,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 @RegisterForReflection
 public class StatsEntry {
     public String entryName;
+    public String timeWindow;
     public Integer created;
     public Integer createdAndClosedNow;
     public Integer createdAndOpenNow;

--- a/src/main/resources/templates/StatusResource/issues.html
+++ b/src/main/resources/templates/StatusResource/issues.html
@@ -43,6 +43,11 @@
 						"{entry.entryName}",
 					{/for}
 					],
+					timeWindows: [
+					{#for entry in stats.entries}
+						"{entry.timeWindow}",
+					{/for}
+					],
 					datasets: [{
 						label: 'Closed',
 						backgroundColor: "#00CC00",
@@ -104,8 +109,8 @@
 				if(array[0]) {
 					// console.table(array[0]);
 					var issuesState = array[0].datasetIndex == 0 ? "closed" : "open";
-					var label = barChartConfig.data.labels[array[0].index];
-					window.open("https://github.com/quarkusio/quarkus/issues?q=label:{stats.label}+is:issue+is:" + issuesState + "+created:" + label, '_blank');
+					var timeWindow = barChartConfig.data.timeWindows[array[0].index];
+					window.open("https://github.com/quarkusio/quarkus/issues?q=label:{stats.label}+is:issue+is:" + issuesState + "+created:" + timeWindow, '_blank');
 				}
 			}
 			var lineChartConfig = {


### PR DESCRIPTION
Fix GitHub links in https://status.quarkus.io/bugs/ charts by using full format for the time window string

old link: https://github.com/quarkusio/quarkus/issues?q=label:kind/bug+is:issue+is:closed+created:2023-03
new link: https://github.com/quarkusio/quarkus/issues?q=label:kind/bug+is:issue+is:closed+created:2023-03-01..2023-03-31

Short time range definition (e.g. `2023-03`) does not work on GitHub anymore. It worked for sure, but could be a side-effect as docs (https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax#query-for-dates) are not mentioning this way